### PR TITLE
Replaced hardcoded URL scheme occurrences

### DIFF
--- a/00-Login/Auth0Sample/Info.plist
+++ b/00-Login/Auth0Sample/Info.plist
@@ -29,7 +29,7 @@
 			<string>auth0</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>auth0.samples.Auth0Sample</string>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 	</array>

--- a/03-User-Sessions/Auth0Sample/Info.plist
+++ b/03-User-Sessions/Auth0Sample/Info.plist
@@ -29,7 +29,7 @@
 			<string>auth0</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>auth0.samples.Auth0Sample</string>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 	</array>

--- a/04-Calling-APIs/Auth0Sample/Info.plist
+++ b/04-Calling-APIs/Auth0Sample/Info.plist
@@ -57,7 +57,7 @@
             <string>auth0</string>
             <key>CFBundleURLSchemes</key>
             <array>
-                <string>auth0.samples.Auth0Sample</string>
+                <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
             </array>
         </dict>
     </array>

--- a/05-Authorization/Auth0Sample/Info.plist
+++ b/05-Authorization/Auth0Sample/Info.plist
@@ -52,7 +52,7 @@
             <string>auth0</string>
             <key>CFBundleURLSchemes</key>
             <array>
-                <string>auth0.samples.Auth0Sample</string>
+                <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
             </array>
         </dict>
     </array>

--- a/07-Linking-Accounts/Auth0Sample/Info.plist
+++ b/07-Linking-Accounts/Auth0Sample/Info.plist
@@ -52,7 +52,7 @@
 			<string>auth0</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>auth0.samples.Auth0Sample</string>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 	</array>

--- a/08-Credentials-TouchID/Auth0Sample/Info.plist
+++ b/08-Credentials-TouchID/Auth0Sample/Info.plist
@@ -29,7 +29,7 @@
 			<string>auth0</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>auth0.samples.Auth0Sample</string>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
In every exercise, the sample app uses a hardcoded string as a custom URL scheme (`auth0.samples.Auth0Sample`). In the [Swift Quickstart](https://auth0.com/docs/quickstart/native/ios-swift/00-login#configure-callback-urls) the variable `$(PRODUCT_BUNDLE_IDENTIFIER)` is used instead. 

This PR updates the sample apps to match.