### PR TITLE
Improve the sample configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auth0 Swift Samples
 
-This is the sample application for the [Auth0 Swift Quickstart](https://auth0.com/docs/quickstart/native/ios-swift/00-login) using the [Auth0.swift](https://github.com/auth0/Auth0.swift/tree/beta) SDK. The sample source code can be found in the [Sample-01 directory](Sample-01).
+This is the sample application for the [Auth0 Swift Quickstart](https://auth0.com/docs/quickstart/native/swift-beta) using the [Auth0.swift](https://github.com/auth0/Auth0.swift/tree/beta) SDK. The sample source code can be found in the [Sample-01 directory](Sample-01).
 
 ## Issue Reporting
 

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -15,26 +15,9 @@ Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application 
 
 There are two application targets available: **SwiftSample (iOS)** for the iOS sample and **SwiftSample (macOS)** for the macOS sample. 
 
-### Configure Client ID and Domain
+### Configure Auth0 Application
 
-Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and Domain of your [Auth0 application](https://manage.auth0.com/#/applications/):
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>ClientId</key>
-  <string>{CLIENT_ID}</string>
-  <key>Domain</key>
-  <string>{DOMAIN}</string>
-</dict>
-</plist>
-```
-
-### Configure Callback URL
-
-Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the corresponding URL to the **Allowed Callback URLs** field.
+Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the following value to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your application.
 
 #### iOS
 
@@ -48,15 +31,30 @@ YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback
 YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-E.g. if the iOS bundle identifier you configured was `com.company.myapp` and your Auth0 Domain was `company.us.auth0.com`, then this value would be:
+E.g. if your iOS bundle identifier was `com.company.myapp` and your Auth0 Domain was `company.us.auth0.com`, then this value would be:
 
 ```text
 com.company.myapp://company.us.auth0.com/ios/com.company.myapp/callback
 ```
 
-### Configure Logout URL
+> ⚠️ Make sure that the [application type](https://auth0.com/docs/configure/applications) of the Auth0 application is **Native**. If you don’t have a Native Auth0 application, [create one](https://auth0.com/docs/get-started/create-apps/native-apps) before continuing.
 
-Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and copy the **Allowed Callback URLs** value you just added into the **Allowed Logout URLs** field.
+### Configure Auth0.swift
+
+Back in Xcode, rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and Domain of your Auth0 application. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), use the value of your Custom Domain instead of the value from the settings page.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>ClientId</key>
+    <string>{CLIENT_ID}</string>
+    <key>Domain</key>
+    <string>{DOMAIN}</string>
+</dict>
+</plist>
+```
 
 ## Issue Reporting
 

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -13,7 +13,7 @@ This sample application demonstrates the integration of the [Auth0.swift](https:
 
 Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. Change the default bundle identifier from `com.auth0.samples.SwiftSample` to another value of your choosing.
 
-There are two application targets available: **SwiftSample (iOS)** for the iOS sample and **SwiftSample (macOS)** for the macOS sample. 
+There are two application targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. 
 
 ### 2. Configure Auth0 Application
 

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -1,6 +1,6 @@
 # Swift Sample Application
 
-This sample application demonstrates the integration of the [Auth0.swift](https://github.com/auth0/Auth0.swift/tree/beta) SDK into a Swift iOS / macOS application. The sample is a companion to the [Auth0 Swift Quickstart](https://auth0.com/docs/quickstart/native/ios-swift/00-login).
+This sample application demonstrates the integration of the [Auth0.swift](https://github.com/auth0/Auth0.swift/tree/beta) SDK into a Swift iOS / macOS application. The sample is a companion to the [Auth0 Swift Quickstart](https://auth0.com/docs/quickstart/native/swift-beta).
 
 ## Requirements
 
@@ -9,13 +9,13 @@ This sample application demonstrates the integration of the [Auth0.swift](https:
 
 ## Configuration
 
-### Configure Bundle Identifier
+### 1. Configure Bundle Identifier
 
 Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. Change the default bundle identifier from `com.auth0.samples.SwiftSample` to another value of your choosing.
 
 There are two application targets available: **SwiftSample (iOS)** for the iOS sample and **SwiftSample (macOS)** for the macOS sample. 
 
-### Configure Auth0 Application
+### 2. Configure Auth0 Application
 
 Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the following value to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your application.
 
@@ -39,7 +39,7 @@ com.company.myapp://company.us.auth0.com/ios/com.company.myapp/callback
 
 > ⚠️ Make sure that the [application type](https://auth0.com/docs/configure/applications) of the Auth0 application is **Native**. If you don’t have a Native Auth0 application, [create one](https://auth0.com/docs/get-started/create-apps/native-apps) before continuing.
 
-### Configure Auth0.swift
+### 3. Configure Auth0.swift
 
 Back in Xcode, rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and Domain of your Auth0 application. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), use the value of your Custom Domain instead of the value from the settings page.
 


### PR DESCRIPTION
### Description

This PR reorganizes the configuration instructions in the sample README for clarity and ease, and adds a couple of missing details. The Quickstart links were also updated to point to the new [beta Quickstart](https://auth0.com/docs/quickstart/native/swift-beta).