### PR TITLE
Add e2e smoke tests [SDK-3053]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ commands:
           command: |
             SIMULATOR='platform=iOS Simulator,name=iPhone 12'
             if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              sed -i '' -e "s/{DOMAIN}/$AUTH0_DOMAIN/" Sample-01/Auth0.plist
+              sed -i '' -e "s/{CLIENT_ID}/$AUTH0_CLIENT_ID/" Sample-01/Auth0.plist
               xcodebuild test \
               -project 'Sample-01/<< parameters.scheme >>.xcodeproj' \
               -scheme '<< parameters.scheme >> (iOS)' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
       - run:
           name: Run iOS tests
           command: |
-            SIMULATOR='platform=iOS Simulator,name=iPhone 12'
+            SIMULATOR='platform=iOS Simulator,name=iPhone 13'
             if [ -z "$CIRCLE_PR_NUMBER" ]; then
               sed -i '' -e "s/{DOMAIN}/$AUTH0_DOMAIN/" Sample-01/Auth0.plist
               sed -i '' -e "s/{CLIENT_ID}/$AUTH0_CLIENT_ID/" Sample-01/Auth0.plist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,22 @@ commands:
     steps:
       - run:
           name: Run iOS tests
-          command: xcodebuild test -project 'Sample-01/<< parameters.scheme >>.xcodeproj' -scheme '<< parameters.scheme >> (iOS)' -destination 'platform=iOS Simulator,name=IPhone 12' | xcpretty
+          command: |
+            SIMULATOR='platform=iOS Simulator,name=iPhone 12'
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              xcodebuild test \
+              -project 'Sample-01/<< parameters.scheme >>.xcodeproj' \
+              -scheme '<< parameters.scheme >> (iOS)' \
+              -destination "$SIMULATOR" \
+              -configuration Debug | xcpretty
+            else
+              xcodebuild test \
+              -project 'Sample-01/<< parameters.scheme >>.xcodeproj' \
+              -scheme '<< parameters.scheme >> (iOS)' \
+              -destination "$SIMULATOR" \
+              -configuration Debug \
+              -skip-testing:<< parameters.scheme >>UITests | xcpretty
+            fi
   build-macos:
     parameters:
       scheme:
@@ -40,7 +55,7 @@ commands:
     steps:
       - run:
           name: Run macOS tests
-          command: xcodebuild test -project 'Sample-01/<< parameters.scheme >>.xcodeproj' -scheme '<< parameters.scheme >> (macOS)' -destination 'platform=macOS,arch=x86_64' | xcpretty
+          command: xcodebuild test -project 'Sample-01/<< parameters.scheme >>.xcodeproj' -scheme '<< parameters.scheme >> (macOS)' -destination 'platform=macOS,arch=x86_64' -configuration Debug | xcpretty
 
 jobs:
   build:

--- a/Sample-01/SwiftSample.xcodeproj/project.pbxproj
+++ b/Sample-01/SwiftSample.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		5CD3A4792785237000B67D88 /* ProfileViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD3A4772785237000B67D88 /* ProfileViewTests.swift */; };
 		5CD3A4832785EB1000B67D88 /* ProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD3A4822785EB1000B67D88 /* ProfileTests.swift */; };
 		5CD3A4842785EB1000B67D88 /* ProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD3A4822785EB1000B67D88 /* ProfileTests.swift */; };
+		5CD3A48F2788DFCD00B67D88 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD3A48E2788DFCD00B67D88 /* SmokeTests.swift */; };
 		5CDD8865277102DC00052307 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDD8855277102DA00052307 /* App.swift */; };
 		5CDD8866277102DC00052307 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDD8855277102DA00052307 /* App.swift */; };
 		5CDD8867277102DC00052307 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDD8856277102DA00052307 /* MainView.swift */; };
@@ -53,6 +54,13 @@
 			remoteGlobalIDString = 5CDD8861277102DC00052307;
 			remoteInfo = "SwiftSample (macOS)";
 		};
+		5CD3A4902788DFCD00B67D88 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5CDD8850277102DA00052307 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5CDD885B277102DC00052307;
+			remoteInfo = "SwiftSample (iOS)";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +78,8 @@
 		5CD3A4732785217600B67D88 /* ProfileCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCellTests.swift; sourceTree = "<group>"; };
 		5CD3A4772785237000B67D88 /* ProfileViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewTests.swift; sourceTree = "<group>"; };
 		5CD3A4822785EB1000B67D88 /* ProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTests.swift; sourceTree = "<group>"; };
+		5CD3A48A2788DFCD00B67D88 /* SwiftSampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftSampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CD3A48E2788DFCD00B67D88 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		5CDD8855277102DA00052307 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		5CDD8856277102DA00052307 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		5CDD8857277102DC00052307 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -92,6 +102,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				5CD3A4672784F61200B67D88 /* ViewInspector in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5CD3A4872788DFCD00B67D88 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -184,11 +201,20 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
+		5CD3A48B2788DFCD00B67D88 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				5CD3A48E2788DFCD00B67D88 /* SmokeTests.swift */,
+			);
+			path = UITests;
+			sourceTree = "<group>";
+		};
 		5CDD884F277102DA00052307 = {
 			isa = PBXGroup;
 			children = (
 				5C5DBE8A277217D800E19935 /* Sources */,
 				5CD3A4522784E56300B67D88 /* Tests */,
+				5CD3A48B2788DFCD00B67D88 /* UITests */,
 				5CDD885D277102DC00052307 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -200,6 +226,7 @@
 				5CDD8862277102DC00052307 /* SwiftSample.app */,
 				5CD3A4492784E54E00B67D88 /* SwiftSampleTests (iOS).xctest */,
 				5CD3A4572784E5BC00B67D88 /* SwiftSampleTests (macOS).xctest */,
+				5CD3A48A2788DFCD00B67D88 /* SwiftSampleUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -256,6 +283,24 @@
 			productName = "SwiftSampleTests (macOS)";
 			productReference = 5CD3A4572784E5BC00B67D88 /* SwiftSampleTests (macOS).xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		5CD3A4892788DFCD00B67D88 /* SwiftSampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5CD3A4942788DFCD00B67D88 /* Build configuration list for PBXNativeTarget "SwiftSampleUITests" */;
+			buildPhases = (
+				5CD3A4862788DFCD00B67D88 /* Sources */,
+				5CD3A4872788DFCD00B67D88 /* Frameworks */,
+				5CD3A4882788DFCD00B67D88 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5CD3A4912788DFCD00B67D88 /* PBXTargetDependency */,
+			);
+			name = SwiftSampleUITests;
+			productName = "SwiftSampleUITests (iOS)";
+			productReference = 5CD3A48A2788DFCD00B67D88 /* SwiftSampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		5CDD885B277102DC00052307 /* SwiftSample (iOS) */ = {
 			isa = PBXNativeTarget;
@@ -317,6 +362,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						TestTargetID = 5CDD8861277102DC00052307;
 					};
+					5CD3A4892788DFCD00B67D88 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = 5CDD885B277102DC00052307;
+					};
 					5CDD885B277102DC00052307 = {
 						CreatedOnToolsVersion = 13.2;
 					};
@@ -346,6 +395,7 @@
 				5CDD8861277102DC00052307 /* SwiftSample (macOS) */,
 				5CD3A4482784E54E00B67D88 /* SwiftSampleTests (iOS) */,
 				5CD3A4562784E5BC00B67D88 /* SwiftSampleTests (macOS) */,
+				5CD3A4892788DFCD00B67D88 /* SwiftSampleUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -359,6 +409,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		5CD3A4552784E5BC00B67D88 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5CD3A4882788DFCD00B67D88 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -450,6 +507,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5CD3A4862788DFCD00B67D88 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CD3A48F2788DFCD00B67D88 /* SmokeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5CDD8858277102DC00052307 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -486,6 +551,11 @@
 			isa = PBXTargetDependency;
 			target = 5CDD8861277102DC00052307 /* SwiftSample (macOS) */;
 			targetProxy = 5CD3A45B2784E5BC00B67D88 /* PBXContainerItemProxy */;
+		};
+		5CD3A4912788DFCD00B67D88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5CDD885B277102DC00052307 /* SwiftSample (iOS) */;
+			targetProxy = 5CD3A4902788DFCD00B67D88 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -562,6 +632,45 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwiftSample.app/Contents/MacOS/SwiftSample";
+			};
+			name = Release;
+		};
+		5CD3A4922788DFCD00B67D88 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22U9KJ5PK6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.samples.SwiftSampleUITests--iOS-";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "SwiftSample (iOS)";
+			};
+			name = Debug;
+		};
+		5CD3A4932788DFCD00B67D88 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22U9KJ5PK6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.samples.SwiftSampleUITests--iOS-";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "SwiftSample (iOS)";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -806,6 +915,15 @@
 			buildConfigurations = (
 				5CD3A45E2784E5BC00B67D88 /* Debug */,
 				5CD3A45F2784E5BC00B67D88 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5CD3A4942788DFCD00B67D88 /* Build configuration list for PBXNativeTarget "SwiftSampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CD3A4922788DFCD00B67D88 /* Debug */,
+				5CD3A4932788DFCD00B67D88 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sample-01/SwiftSample.xcodeproj/xcshareddata/xcschemes/SwiftSample (iOS).xcscheme
+++ b/Sample-01/SwiftSample.xcodeproj/xcshareddata/xcschemes/SwiftSample (iOS).xcscheme
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CDD885B277102DC00052307"
+               BuildableName = "SwiftSample.app"
+               BlueprintName = "SwiftSample (iOS)"
+               ReferencedContainer = "container:SwiftSample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CD3A4892788DFCD00B67D88"
+            BuildableName = "SwiftSampleUITests (iOS).xctest"
+            BlueprintName = "SwiftSampleUITests"
+            ReferencedContainer = "container:SwiftSample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "USER_EMAIL"
+            value = "$(USER_EMAIL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "USER_PASSWORD"
+            value = "$(USER_PASSWORD)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CD3A4482784E54E00B67D88"
+               BuildableName = "SwiftSampleTests (iOS).xctest"
+               BlueprintName = "SwiftSampleTests (iOS)"
+               ReferencedContainer = "container:SwiftSample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CD3A4892788DFCD00B67D88"
+               BuildableName = "SwiftSampleUITests (iOS).xctest"
+               BlueprintName = "SwiftSampleUITests"
+               ReferencedContainer = "container:SwiftSample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CDD885B277102DC00052307"
+            BuildableName = "SwiftSample.app"
+            BlueprintName = "SwiftSample (iOS)"
+            ReferencedContainer = "container:SwiftSample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CDD885B277102DC00052307"
+            BuildableName = "SwiftSample.app"
+            BlueprintName = "SwiftSample (iOS)"
+            ReferencedContainer = "container:SwiftSample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sample-01/UITests/SmokeTests.swift
+++ b/Sample-01/UITests/SmokeTests.swift
@@ -55,8 +55,8 @@ private extension SmokeTests {
         emailInput.typeText("\(email)\n")
         let passwordInput = app.webViews.secureTextFields.firstMatch
         passwordInput.tap()
-        passwordInput.typeText("\(password)\n")
-        // app.webViews.buttons.firstMatch.tap()
+        passwordInput.typeText(password)
+        app.webViews.buttons.firstMatch.tap()
     }
 
 }

--- a/Sample-01/UITests/SmokeTests.swift
+++ b/Sample-01/UITests/SmokeTests.swift
@@ -52,6 +52,7 @@ private extension SmokeTests {
         let passwordInput = app.webViews.secureTextFields.element(boundBy: 0)
         XCTAssertTrue(passwordInput.waitForExistence(timeout: timeout))
         passwordInput.tap()
+        sleep(1)
         passwordInput.typeText(password)
         app.webViews.buttons[continueButton].tap()
     }

--- a/Sample-01/UITests/SmokeTests.swift
+++ b/Sample-01/UITests/SmokeTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+class SmokeTests: XCTestCase {
+
+    private let email = ProcessInfo.processInfo.environment["USER_EMAIL"]!
+    private let password = ProcessInfo.processInfo.environment["USER_PASSWORD"]!
+    private let loginButton = "Login"
+    private let logoutButton = "Logout"
+    private let continueButton = "Continue"
+    private let timeout: TimeInterval = 10
+
+    override func setUp() {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchEnvironment = ProcessInfo.processInfo.environment
+        app.launch()
+        app.buttons[loginButton].tap()
+        tapAlert(button: continueButton)
+    }
+
+    func testLogin() {
+        let app = XCUIApplication()
+        login()
+        XCTAssertTrue(app.buttons[logoutButton].waitForExistence(timeout: timeout))
+        XCTAssertTrue(app.staticTexts[email].waitForExistence(timeout: timeout))
+    }
+
+    func testLogout() {
+        let app = XCUIApplication()
+        app.buttons[logoutButton].tap()
+        tapAlert(button: continueButton)
+        XCTAssertTrue(app.buttons[loginButton].waitForExistence(timeout: timeout))
+    }
+
+}
+
+private extension SmokeTests {
+
+    func tapAlert(button label: String) {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let button = springboard.buttons[label]
+        XCTAssertTrue(button.waitForExistence(timeout: timeout))
+        button.tap()
+    }
+
+    func login() {
+        let app = XCUIApplication()
+        let emailInput = app.webViews.textFields.element(boundBy: 0)
+        XCTAssertTrue(emailInput.waitForExistence(timeout: timeout))
+        emailInput.tap()
+        emailInput.typeText(email)
+        let passwordInput = app.webViews.secureTextFields.element(boundBy: 0)
+        XCTAssertTrue(passwordInput.waitForExistence(timeout: timeout))
+        passwordInput.tap()
+        passwordInput.typeText(password)
+        app.webViews.buttons[continueButton].tap()
+    }
+
+}

--- a/Sample-01/UITests/SmokeTests.swift
+++ b/Sample-01/UITests/SmokeTests.swift
@@ -27,6 +27,10 @@ class SmokeTests: XCTestCase {
 
     func testLogout() {
         let app = XCUIApplication()
+        let sessionButton = app.webViews.staticTexts[email]
+        XCTAssertTrue(sessionButton.waitForExistence(timeout: timeout))
+        sessionButton.tap()
+        XCTAssertTrue(app.buttons[logoutButton].waitForExistence(timeout: timeout))
         app.buttons[logoutButton].tap()
         tapAlert(button: continueButton)
         XCTAssertTrue(app.buttons[loginButton].waitForExistence(timeout: timeout))
@@ -45,16 +49,14 @@ private extension SmokeTests {
 
     func login() {
         let app = XCUIApplication()
-        let emailInput = app.webViews.textFields.element(boundBy: 0)
+        let emailInput = app.webViews.textFields.firstMatch
         XCTAssertTrue(emailInput.waitForExistence(timeout: timeout))
         emailInput.tap()
-        emailInput.typeText(email)
-        let passwordInput = app.webViews.secureTextFields.element(boundBy: 0)
-        XCTAssertTrue(passwordInput.waitForExistence(timeout: timeout))
+        emailInput.typeText("\(email)\n")
+        let passwordInput = app.webViews.secureTextFields.firstMatch
         passwordInput.tap()
-        sleep(1)
-        passwordInput.typeText(password)
-        app.webViews.buttons[continueButton].tap()
+        passwordInput.typeText("\(password)\n")
+        // app.webViews.buttons.firstMatch.tap()
     }
 
 }


### PR DESCRIPTION
### Description

This PR adds basic iOS-only e2e tests that cover login and logout.
The CI config file was updated to not run the e2e tests for forked PRs, and the corresponding setting was verified to be set in the CI panel as well:

<img width="1030" alt="Screen Shot 2022-01-10 at 23 30 42" src="https://user-images.githubusercontent.com/5055789/148872017-8e113a97-dc1f-4e0a-9d5b-4c29fb53ad44.png">