### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.swift text diff=swift
-*.otf   binary
+*.ttf   binary

--- a/Sample-01/SwiftSample.xcodeproj/xcshareddata/xcschemes/SwiftSample (iOS).xcscheme
+++ b/Sample-01/SwiftSample.xcodeproj/xcshareddata/xcschemes/SwiftSample (iOS).xcscheme
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5CD3A4892788DFCD00B67D88"
-            BuildableName = "SwiftSampleUITests (iOS).xctest"
+            BuildableName = "SwiftSampleUITests.xctest"
             BlueprintName = "SwiftSampleUITests"
             ReferencedContainer = "container:SwiftSample.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5CD3A4892788DFCD00B67D88"
-               BuildableName = "SwiftSampleUITests (iOS).xctest"
+               BuildableName = "SwiftSampleUITests.xctest"
                BlueprintName = "SwiftSampleUITests"
                ReferencedContainer = "container:SwiftSample.xcodeproj">
             </BuildableReference>


### PR DESCRIPTION
### Description

The `.gitattributes` file had an entry for .otf files. Now that the custom font file used in the sample was [changed](https://github.com/auth0-samples/auth0-ios-swift-sample/pull/84) from OTF to TTF, the entry was updated accordingly.