### PR TITLE
Fix Xcode project settings

### DIFF
--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -4,7 +4,7 @@ This sample application demonstrates the integration of the [Auth0.swift](https:
 
 ## Requirements
 
-- iOS 12+ / macOS 10.15+
+- iOS 15+ / macOS 11+
 - Xcode 13.x
 
 ## Configuration
@@ -15,15 +15,15 @@ Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application 
 
 ### 2. Configure Auth0 Application
 
-Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the following value to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your application.
+Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add a URL to **Allowed Callback URLs** and **Allowed Logout URLs** as follows, according to the application target you want to run. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with the value of your Custom Domain instead of the value from the settings page.
 
-#### iOS
+#### SwiftSample (iOS)
 
 ```text
 YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-#### macOS
+#### SwiftSample (macOS)
 
 ```text
 YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback
@@ -39,7 +39,7 @@ com.company.myapp://company.us.auth0.com/ios/com.company.myapp/callback
 
 ### 3. Configure Auth0.swift
 
-Back in Xcode, rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and Domain of your Auth0 application. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), use the value of your Custom Domain instead of the value from the settings page.
+Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and Domain of your Auth0 application. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), use the value of your Custom Domain instead of the value from the settings page.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -15,7 +15,7 @@ Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application 
 
 ### 2. Configure Auth0 Application
 
-Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add a URL to **Allowed Callback URLs** and **Allowed Logout URLs** as follows, according to the application target you want to run. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with the value of your Custom Domain instead of the value from the settings page.
+Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the corresponding URL to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the application target you want to run. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with the value of your Custom Domain instead of the value from the settings page.
 
 #### SwiftSample (iOS)
 

--- a/Sample-01/SwiftSample.xcodeproj/project.pbxproj
+++ b/Sample-01/SwiftSample.xcodeproj/project.pbxproj
@@ -800,7 +800,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -830,7 +830,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -851,7 +851,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_ENTITLEMENTS = "Sources/Supporting Files/macOS/macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -877,7 +877,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_ENTITLEMENTS = "Sources/Supporting Files/macOS/macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
### ✏️ Changes

This PR sets the `IPHONEOS_DEPLOYMENT_TARGET` to `15.0` instead of `15.2`, fixes the `CODE_SIGN_ENTITLEMENTS` path for the macOS target, and updates the README accordingly.

Also the README was updates to always mention to use the Custom Domain (when set up) instead of the Auth0 Domain, whenever the Auth0 Domain needs to be used.

### ✅ Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
