### PR TITLE
Update the GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Auth0 Community
+  - name: 🤔 Help & Questions
     url: https://community.auth0.com/tags/c/sdks/5/swift
-    about: Ask general questions in the Auth0 Community forums
+    about: Ask general support or usage questions in the Auth0 Community forums

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: 🧩 Feature request
 about: Suggest an idea or a feature for this sample
 title: ''
 labels: feature request
@@ -7,21 +7,25 @@ assignees: ''
 ---
 
 <!--
-⚠️ Please do not report security vulnerabilities here. The Responsible Disclosure Program details the procedure for disclosing security issues: https://auth0.com/responsible-disclosure-policy
-ℹ️ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
-
-Please read through the template below and answer all relevant sections. Your additional work here is greatly appreciated and will help us respond as quickly as possible. To avoid duplicates, please search existing issues before submitting one here.
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
 
 By submitting an issue to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
 -->
 
-### ✏️ Describe the problem you'd like to have solved
+- [ ] I have looked into the [README](https://github.com/auth0-samples/auth0-ios-swift-sample/blob/master/Sample-01/README.md) and have not found a suitable solution or answer
+- [ ] I have searched the [issues](https://github.com/auth0/Auth0.swift/issues) and have not found a suitable solution or answer
 
 <!-- 
-A clear and concise description of what the problem is. E.g. I'm always frustrated when...
+❗ All the above items are required. Issues with an incomplete or missing checklist will be unceremoniously closed.
 -->
 
-### ✏️ Describe the ideal solution
+### 💥 Describe the problem you'd like to have solved
+
+<!-- 
+A clear and concise description of what the problem is. For example, I'm always frustrated when...
+-->
+
+### ✨ Describe the ideal solution
 
 <!-- 
 A clear and concise description of what you want to happen.
@@ -38,12 +42,3 @@ A clear and concise description of any alternatives you've considered or any wor
 <!-- 
 Add any other context or screenshots about the feature request here.
 -->
-
-### ✅ Checklist
-
-<!-- 
-⚠️ These are all required. Issues with an incomplete or missing checklist will be unceremoniously closed.
--->
-
-- [ ] I have looked into the [README](https://github.com/auth0-samples/auth0-ios-swift-sample/blob/master/Sample-01/README.md) and have not found a suitable solution or answer
-- [ ] I have searched the [issues](https://github.com/auth0/Auth0.swift/issues) and have not found a suitable solution or answer

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,21 +1,25 @@
 ---
-name: Report a bug
+name: 🐞 Report a bug
 about: Have you found a bug or issue? Create a bug report for this sample
 title: ''
-labels: bug report
+labels: ''
 assignees: ''
 ---
 
 <!--
-⚠️ Please do not report security vulnerabilities here. The Responsible Disclosure Program details the procedure for disclosing security issues: https://auth0.com/responsible-disclosure-policy
-ℹ️ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
-
-Please read through the template below and answer all relevant sections. Your additional work here is greatly appreciated and will help us respond as quickly as possible. To avoid duplicates, please search existing issues before submitting one here.
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
 
 By submitting an issue to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
 -->
 
-### ✏️ Description
+- [ ] I have looked into the [README](https://github.com/auth0-samples/auth0-ios-swift-sample/blob/master/Sample-01/README.md) and have not found a suitable solution or answer
+- [ ] I have searched the [issues](https://github.com/auth0-samples/auth0-ios-swift-sample/issues) and have not found a suitable solution or answer
+
+<!-- 
+❗ All the above items are required. Issues with an incomplete or missing checklist will be unceremoniously closed.
+-->
+
+### 📝 Description
 
 <!-- 
 Provide a clear and concise description of the issue, including what you expected to happen.
@@ -24,9 +28,9 @@ Provide a clear and concise description of the issue, including what you expecte
 ### 📋 Reproduction
 
 <!-- 
-ℹ️ If clear, reproducible steps cannot be provided, we may not be able to follow up on this bug report.
+❗ If clear, reproducible steps cannot be provided, we may not be able to follow up on this bug report. Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent.
 
-Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent. Where applicable, please include:
+Where applicable, include:
 
 - Log information and HTTP request traces (redact/remove sensitive information)
 - Application settings (redact/remove sensitive information)
@@ -43,12 +47,3 @@ Detail the steps taken to reproduce this error, and whether this issue can be re
 - **Platform (iOS/macOS)**:
 - **Platform version**:
 - **Xcode version**:
-
-### ✅ Checklist
-
-<!-- 
-⚠️ These are all required. Issues with an incomplete or missing checklist will be unceremoniously closed.
--->
-
-- [ ] I have looked into the [README](https://github.com/auth0-samples/auth0-ios-swift-sample/blob/master/Sample-01/README.md) and have not found a suitable solution or answer
-- [ ] I have searched the [issues](https://github.com/auth0-samples/auth0-ios-swift-sample/issues) and have not found a suitable solution or answer

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,19 @@
 <!--
-⚠️ Please do not report security vulnerabilities here. The Responsible Disclosure Program details the procedure for disclosing security issues: https://auth0.com/responsible-disclosure-policy
-ℹ️ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
-
-Please read through the template below and answer all relevant sections. Your additional work here is greatly appreciated and will help us respond as quickly as possible.
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
 
 By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
 -->
 
-### ✏️ Changes
+- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
 
 <!-- 
-Please describe both what is changing and why this is important. Include:
+❗ The above item is required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
+-->
+
+### 📋 Changes
+
+<!-- 
+Describe both what is changing and why this is important. Include:
 
 - Types and methods added, deleted, or changed
 - A summary of usage if this is a new feature
@@ -19,12 +22,12 @@ Please describe both what is changing and why this is important. Include:
 ### 📎 References
 
 <!-- 
-Please include relevant links supporting this change such as a:
+Add relevant links supporting this change, such as:
 
 - GitHub issue/PR number addressed or fixed
 - Auth0 Community post
 - StackOverflow answer
-- Related pull requests/issues from other repos
+- Related pull requests/issues from other repositories
 
 If there are no references, simply delete this section.
 -->
@@ -32,15 +35,7 @@ If there are no references, simply delete this section.
 ### 🎯 Testing
 
 <!-- 
-Describe how this can be tested by reviewers. Be specific about anything not tested and why. Tests must be added for all new functionality. Existing tests must be updated for all changed/fixed functionality, where applicable. All the tests must complete without errors.
+Describe how this can be tested by reviewers. Be specific about anything not tested and why. Tests must be added for all new functionality. Existing tests must be updated for all changed/fixed functionality, where applicable. All tests must complete without errors.
 
-Please include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
+Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
 -->
-
-### ✅ Checklist
-
-<!-- 
-⚠️ This is required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
--->
-
-- [ ] All new/changed/fixed functionality is covered by tests (or N/A)


### PR DESCRIPTION
### ✏️ Changes

This PR updates and simplifies the GitHub templates:

- Moved the checklist items to the top.
- Rephrased some parts.
- Added emojis to the contact links.
- Removed some redundant information that is already present in the README.

### ✅ Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
