### PR TITLE
Use correct assertions for optionals/throwables

### DIFF
--- a/Sample-01/Tests/Shared/ProfileCellTests.swift
+++ b/Sample-01/Tests/Shared/ProfileCellTests.swift
@@ -22,14 +22,14 @@ class ProfileCellTests: XCTestCase {
     }
 
     func testKeyUsesSemiboldFont() throws {
-        let key = try self.sut.inspect().findAll(ViewType.Text.self).first
-        XCTAssertEqual(try key?.attributes().font().weight(), .semibold)
-        XCTAssertEqual(try key?.attributes().font().size(), 14)
+        let key = try XCTUnwrap(try self.sut.inspect().findAll(ViewType.Text.self).first)
+        XCTAssertEqual(try key.attributes().font().weight(), .semibold)
+        XCTAssertEqual(try key.attributes().font().size(), 14)
     }
 
     func testValueUsesRegularFont() throws {
-        let key = try self.sut.inspect().findAll(ViewType.Text.self).last
-        XCTAssertEqual(try key?.attributes().font().weight(), .regular)
-        XCTAssertEqual(try key?.attributes().font().size(), 14)
+        let key = try XCTUnwrap(try self.sut.inspect().findAll(ViewType.Text.self).last)
+        XCTAssertEqual(try key.attributes().font().weight(), .regular)
+        XCTAssertEqual(try key.attributes().font().size(), 14)
     }
 }

--- a/Sample-01/Tests/Shared/ProfileViewTests.swift
+++ b/Sample-01/Tests/Shared/ProfileViewTests.swift
@@ -9,7 +9,7 @@ class ProfileViewTests: XCTestCase {
     func testHasHeader() throws {
         let user = User(id: "", name: "", email: "", emailVerified: "", picture: "", updatedAt: "")
         let sut = ProfileView(user: user)
-        XCTAssertNotNil(try? sut.inspect().list().find(ProfileHeader.self))
+        XCTAssertNoThrow(try sut.inspect().list().find(ProfileHeader.self))
     }
 
     func testHasProfileValues() throws {

--- a/Sample-01/Tests/Shared/UserTests.swift
+++ b/Sample-01/Tests/Shared/UserTests.swift
@@ -13,18 +13,17 @@ extension User: Equatable {
 }
 
 class UserTests: XCTestCase {
-    func testReturnsUserFromIDToken() {
+    func testReturnsUserFromIDToken() throws {
         let idToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb28iLCJuYW1lIjoiYmFyIiwiZW1haWwiOiJmb29AZXhhbXB"
             + "sZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicGljdHVyZSI6ImJheiIsInVwZGF0ZWRfYXQiOiJxdXgifQ.vc9sxvhUVAHowIWJ"
             + "7D_WDzvqJxC4-qYXHmiBVYEKn9E"
-        let sut = User(from: idToken)
-        XCTAssertNotNil(sut)
-        XCTAssertEqual(sut?.id, "foo")
-        XCTAssertEqual(sut?.name, "bar")
-        XCTAssertEqual(sut?.email, "foo@example.com")
-        XCTAssertEqual(sut?.emailVerified, "true")
-        XCTAssertEqual(sut?.picture, "baz")
-        XCTAssertEqual(sut?.updatedAt, "qux")
+        let sut = try XCTUnwrap(User(from: idToken))
+        XCTAssertEqual(sut.id, "foo")
+        XCTAssertEqual(sut.name, "bar")
+        XCTAssertEqual(sut.email, "foo@example.com")
+        XCTAssertEqual(sut.emailVerified, "true")
+        XCTAssertEqual(sut.picture, "baz")
+        XCTAssertEqual(sut.updatedAt, "qux")
     }
 
     func testReturnsNilWhenIDTokenDecodingFails() {

--- a/Sample-01/Tests/iOS/ProfileHeaderTests.swift
+++ b/Sample-01/Tests/iOS/ProfileHeaderTests.swift
@@ -8,7 +8,7 @@ class ProfileHeaderTests: XCTestCase {
     private let sut = ProfileHeader(picture: "")
 
     func testHasAsyncImage() throws {
-        XCTAssertNotNil(try? self.sut.inspect().asyncImage())
+        XCTAssertNoThrow(try self.sut.inspect().asyncImage())
     }
 
     func testAsyncImageUsesFixedSize() throws {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)

<!-- 
❗ The above item is required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR ensures the unit tests use the correct assertions for dealing with optional values and throwable methods: `XCTUnwrap` and `XCTAssertNoThrow`, respectively.