### PR TITLE
Use HTTPS redirect URLs [SDK-4752]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,16 @@ For general support or usage questions, use the [Auth0 Community](https://commun
 
 **Do not report security vulnerabilities on the public GitHub issue tracker.** The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
 
-## What is Auth0?
+---
 
-Auth0 helps you to:
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png" width="150">
+    <img alt="Auth0 Logo" src="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+  </picture>
+</p>
 
-* Add authentication with [multiple sources](https://auth0.com/docs/authenticate/identity-providers), either social identity providers such as **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce** (amongst others), or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS, or any SAML identity provider**.
-* Add authentication through more traditional **[username/password databases](https://auth0.com/docs/authenticate/database-connections/custom-db)**.
-* Add support for **[linking different user accounts](https://auth0.com/docs/manage-users/user-accounts/user-account-linking)** with the same user.
-* Support for generating signed [JSON Web Tokens](https://auth0.com/docs/secure/tokens/json-web-tokens) to call your APIs and **flow the user identity** securely.
-* Analytics of how, when, and where users are logging in.
-* Pull data from other sources and add it to the user profile through [JavaScript Actions](https://auth0.com/docs/customize/actions).
+<p align="center">Auth0 is an easy-to-implement, adaptable authentication and authorization platform. To learn more check out <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
 
-**Why Auth0?** Because you should save time, be happy, and focus on what really matters: building your product.
-
-## License
-
-This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more information.
+<p align="center">This project is licensed under the MIT license. See the <a href="./LICENSE"> LICENSE</a> file for more info.</p>

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -5,41 +5,93 @@ This sample application demonstrates the integration of the [Auth0.swift](https:
 ## Requirements
 
 - iOS 15+ / macOS 11+
-- Xcode 14.x
+- Xcode 14.x / 15.x
+
+> [!NOTE]
+> On iOS 17.4+ and macOS 14.4+ it is possible to use Universal Links as callback and logout URLs. Auth0.swift will fall back to using a custom URL scheme on older iOS / macOS versions.
+>
+> **This feature requires Xcode 15.3+ and a paid Apple Developer account**.
+>
+> If you do not have a paid Apple Developer account, skip steps **2.2** and **3**, and comment out the two `useHTTPS()` calls in `MainView.swift`.
 
 ## Configuration
 
-### 1. Configure Bundle Identifier
+### 1. Configure code signing
 
-Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. There are two application targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. In the **General** tab, change the default bundle identifier from `com.auth0.samples.SwiftSample` to another value of your choosing.
+Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the app target you want to run. There are two app targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. In the **General** tab, change the default bundle identifier from `com.auth0.samples.SwiftSample` to another value of your choosing.
 
-### 2. Configure Auth0 Application
+Then, ensure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
 
-Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the corresponding URL to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the application target you want to run. If you are using a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with the value of your custom domain instead of the value from the settings page.
+### 2. Configure the Auth0 Application
 
-#### SwiftSample (iOS)
+> [!IMPORTANT]
+> Make sure that the Auth0 application type is **Native**. Otherwise, you might run into errors due to the different configuration of other application types.
+
+#### 2.1. Configure the callback and logout URLs
+
+Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the application target you want to run. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
+
+##### SwiftSample (iOS)
 
 ```text
+https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,
 YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-#### SwiftSample (macOS)
+##### SwiftSample (macOS)
 
 ```text
+https://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback,
 YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-For example, if your iOS bundle identifier was `com.company.myapp` and your Auth0 Domain was `company.us.auth0.com`, then this value would be:
+<details>
+  <summary>Example</summary>
+
+If your iOS bundle identifier were `com.example.MyApp` and your Auth0 Domain were `example.us.auth0.com`, then this value would be:
 
 ```text
-com.company.myapp://company.us.auth0.com/ios/com.company.myapp/callback
+https://example.us.auth0.com/ios/com.example.MyApp/callback,
+com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
+```
+</details>
+
+#### 2.2. Configure the Team ID and bundle identifier
+
+Scroll to the end of the settings page of your Auth0 application and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to the app's bundle identifier.
+
+![Screenshot of the iOS section inside the Auth0 application settings page](https://github.com/auth0/Auth0.swift/assets/5055789/7eb5f6a2-7cc7-4c70-acf3-633fd72dc506)
+
+This will add the app to your Auth0 tenant's `apple-app-site-association` file.
+
+### 3. Configure the associated domain
+
+In Xcode, go to the **Signing and Capabilities** tab of the app's target settings. Under **Associated Domains**, find the following entry:
+
+```text
+webcredentials:{YOUR_AUTH0_DOMAIN}
 ```
 
-> ⚠️ Make sure that the [application type](https://auth0.com/docs/get-started/applications) of the Auth0 application is **Native**. If you don’t have a Native Auth0 application already, [create one](https://auth0.com/docs/get-started/auth0-overview/create-applications/native-apps) before continuing.
+Replace the placeholder `{YOUR_AUTH0_DOMAIN}` value with the domain of your Auth0 application.
 
-### 3. Configure Auth0.swift
+<details>
+  <summary>Example</summary>
 
-Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and Domain of your Auth0 application. If you are using a [custom domain](https://auth0.com/docs/customize/custom-domains), use the value of your custom domain instead of the value from the settings page.
+If your Auth0 Domain were `example.us.auth0.com`, then this value would be:
+
+```text
+webcredentials:example.us.auth0.com
+```
+</details>
+
+If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `{YOUR_AUTH0_DOMAIN}` with your custom domain instead of the value from the settings page.
+
+> [!NOTE]
+> For the associated domain to work, the app must be signed with your team certificate **even when building for the iOS simulator**. Make sure you are using the Apple Team whose Team ID is configured in the settings page of your Auth0 application.
+
+### 4. Configure Auth0.swift
+
+Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and domain of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), use it instead of the value from the settings page.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -60,19 +112,16 @@ For general support or usage questions, use the [Auth0 Community](https://commun
 
 **Do not report security vulnerabilities on the public GitHub issue tracker.** The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
 
-## What is Auth0?
+---
 
-Auth0 helps you to:
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png" width="150">
+    <img alt="Auth0 Logo" src="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+  </picture>
+</p>
 
-* Add authentication with [multiple sources](https://auth0.com/docs/authenticate/identity-providers), either social identity providers such as **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce** (amongst others), or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS, or any SAML identity provider**.
-* Add authentication through more traditional **[username/password databases](https://auth0.com/docs/authenticate/database-connections/custom-db)**.
-* Add support for **[linking different user accounts](https://auth0.com/docs/manage-users/user-accounts/user-account-linking)** with the same user.
-* Support for generating signed [JSON Web Tokens](https://auth0.com/docs/secure/tokens/json-web-tokens) to call your APIs and **flow the user identity** securely.
-* Analytics of how, when, and where users are logging in.
-* Pull data from other sources and add it to the user profile through [JavaScript Actions](https://auth0.com/docs/customize/actions).
+<p align="center">Auth0 is an easy-to-implement, adaptable authentication and authorization platform. To learn more check out <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
 
-**Why Auth0?** Because you should save time, be happy, and focus on what really matters: building your product.
-
-## License
-
-This project is licensed under the MIT license. See the [LICENSE](../LICENSE) file for more information.
+<p align="center">This project is licensed under the MIT license. See the <a href="../LICENSE"> LICENSE</a> file for more info.</p>

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -12,33 +12,27 @@ This sample application demonstrates the integration of the [Auth0.swift](https:
 >
 > **This feature requires Xcode 15.3+ and a paid Apple Developer account**.
 >
-> If you do not have a paid Apple Developer account, skip steps **2.2** and **3**, and comment out the two `useHTTPS()` calls in `MainView.swift`.
+> If you do not have a paid Apple Developer account, skip **step 2** and comment out the two `useHTTPS()` calls in `MainView.swift`.
 
 ## Configuration
 
-### 1. Configure code signing
-
-Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the app target you want to run. There are two app targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. In the **General** tab, change the default bundle identifier from `com.auth0.samples.SwiftSample` to another value of your choosing.
-
-Then, ensure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
-
-### 2. Configure the Auth0 Application
+### 1. Configure the callback and logout URLs
 
 > [!IMPORTANT]
-> Make sure that the Auth0 application type is **Native**. Otherwise, you might run into errors due to the different configuration of other application types.
+> Make sure that the Auth0 application type is **Native**. Otherwise, you might run into errors due to the different configurations of other application types.
 
-#### 2.1. Configure the callback and logout URLs
+Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the app target you want to run –either **SwiftSample (iOS)** or **SwiftSample (macOS)**.
 
-Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the application target you want to run. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
+If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
 
-##### SwiftSample (iOS)
+#### SwiftSample (iOS)
 
 ```text
 https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,
 YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-##### SwiftSample (macOS)
+#### SwiftSample (macOS)
 
 ```text
 https://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback,
@@ -56,23 +50,27 @@ com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
 ```
 </details>
 
-#### 2.2. Configure the Team ID and bundle identifier
+### 2. Configure the associated domain
 
-Scroll to the end of the settings page of your Auth0 application and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to the app's bundle identifier.
+### 2.1. Configure the Team ID and bundle identifier
+
+Open the settings page of your Auth0 application, scroll to the end, and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to the app's bundle identifier.
 
 ![Screenshot of the iOS section inside the Auth0 application settings page](https://github.com/auth0/Auth0.swift/assets/5055789/7eb5f6a2-7cc7-4c70-acf3-633fd72dc506)
 
 This will add the app to your Auth0 tenant's `apple-app-site-association` file.
 
-### 3. Configure the associated domain
+### 2.2. Configure the entitlement
 
-In Xcode, go to the **Signing and Capabilities** tab of the app's target settings. Under **Associated Domains**, find the following entry:
+Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the app target you want to run. In the **Signing & Capabilities** tab, change the default bundle identifier from `com.auth0.samples.SwiftSample` to another value of your choosing. Then, ensure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
+
+Under **Associated Domains**, find the following entry:
 
 ```text
-webcredentials:{YOUR_AUTH0_DOMAIN}
+webcredentials:YOUR_AUTH0_DOMAIN
 ```
 
-Replace the placeholder `{YOUR_AUTH0_DOMAIN}` value with the domain of your Auth0 application.
+Replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
 
 <details>
   <summary>Example</summary>
@@ -84,14 +82,12 @@ webcredentials:example.us.auth0.com
 ```
 </details>
 
-If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `{YOUR_AUTH0_DOMAIN}` with your custom domain instead of the value from the settings page.
-
 > [!NOTE]
 > For the associated domain to work, the app must be signed with your team certificate **even when building for the iOS simulator**. Make sure you are using the Apple Team whose Team ID is configured in the settings page of your Auth0 application.
 
-### 4. Configure Auth0.swift
+### 3. Configure Auth0.swift
 
-Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the placeholder `{CLIENT_ID}` and `{DOMAIN}` values with the Client ID and domain of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), use it instead of the value from the settings page.
+Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the `{CLIENT_ID}` and `{DOMAIN}` placeholders with the Client ID and domain of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), use it instead of the value from the settings page.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -14,16 +14,14 @@ This sample application demonstrates the integration of the [Auth0.swift](https:
 >
 > If you do not have a paid Apple Developer account, skip **step 2** and comment out the two `useHTTPS()` calls in `MainView.swift`.
 
+> [!IMPORTANT]
+> On every step, if you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace the `YOUR_AUTH0_DOMAIN` and `{DOMAIN}` placeholders with your custom domain instead of the value from the settings page.
+
 ## Configuration
 
 ### 1. Configure the callback and logout URLs
 
-> [!IMPORTANT]
-> Make sure that the Auth0 application type is **Native**. Otherwise, you might run into errors due to the different configurations of other application types.
-
 Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the app target you want to run –either **SwiftSample (iOS)** or **SwiftSample (macOS)**.
-
-If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
 
 #### SwiftSample (iOS)
 
@@ -50,6 +48,9 @@ com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
 ```
 </details>
 
+> [!IMPORTANT]
+> Make sure that the Auth0 application type is **Native**. Otherwise, you might run into errors due to the different configurations of other application types.
+
 ### 2. Configure the associated domain
 
 ### 2.1. Configure the Team ID and bundle identifier
@@ -70,7 +71,7 @@ Under **Associated Domains**, find the following entry:
 webcredentials:YOUR_AUTH0_DOMAIN
 ```
 
-Replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
+Replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application.
 
 <details>
   <summary>Example</summary>
@@ -87,7 +88,7 @@ webcredentials:example.us.auth0.com
 
 ### 3. Configure Auth0.swift
 
-Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the `{CLIENT_ID}` and `{DOMAIN}` placeholders with the Client ID and domain of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), use it instead of the value from the settings page.
+Rename the `Auth0.plist.example` file to `Auth0.plist`, and replace the `{CLIENT_ID}` and `{DOMAIN}` placeholders with the Client ID and domain of your Auth0 application.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Sample-01/Sources/MainView.swift
+++ b/Sample-01/Sources/MainView.swift
@@ -23,6 +23,7 @@ extension MainView {
     func login() {
         Auth0
             .webAuth()
+            .useHTTPS() // Use a Universal Link callback URL on iOS 17.4+ / macOS 14.4+
             .start { result in
                 switch result {
                 case .success(let credentials):
@@ -36,6 +37,7 @@ extension MainView {
     func logout() {
         Auth0
             .webAuth()
+            .useHTTPS() // Use a Universal Link logout URL on iOS 17.4+ / macOS 14.4+
             .clearSession { result in
                 switch result {
                 case .success:

--- a/Sample-01/Sources/Supporting Files/macOS/macOS.entitlements
+++ b/Sample-01/Sources/Supporting Files/macOS/macOS.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>webcredentials:{YOUR_AUTH0_DOMAIN}</string>
+		<string>webcredentials:YOUR_AUTH0_DOMAIN</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>

--- a/Sample-01/SwiftSample (iOS).entitlements
+++ b/Sample-01/SwiftSample (iOS).entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>webcredentials:{YOUR_AUTH0_DOMAIN}</string>
+		<string>webcredentials:YOUR_AUTH0_DOMAIN</string>
 	</array>
 </dict>
 </plist>

--- a/Sample-01/SwiftSample (iOS).entitlements
+++ b/Sample-01/SwiftSample (iOS).entitlements
@@ -6,13 +6,5 @@
 	<array>
 		<string>webcredentials:{YOUR_AUTH0_DOMAIN}</string>
 	</array>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 </dict>
 </plist>

--- a/Sample-01/SwiftSample.xcodeproj/project.pbxproj
+++ b/Sample-01/SwiftSample.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		5C6537232772F5D90035759D /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		5C6537262772F5EE0035759D /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		5C78D9C027740963000B4B71 /* Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views.swift; sourceTree = "<group>"; };
+		5CA7AC192B893232008EBDCF /* SwiftSample (iOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SwiftSample (iOS).entitlements"; sourceTree = "<group>"; };
 		5CD3A4492784E54E00B67D88 /* SwiftSampleTests (iOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftSampleTests (iOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CD3A4572784E5BC00B67D88 /* SwiftSampleTests (macOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftSampleTests (macOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CD3A46A27850B9000B67D88 /* HeroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroViewTests.swift; sourceTree = "<group>"; };
@@ -146,6 +147,7 @@
 		5C65372C2773FCFA0035759D /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				5CA7AC192B893232008EBDCF /* SwiftSample (iOS).entitlements */,
 				D569776C278D97D3008E6498 /* SpaceGrotesk.ttf */,
 			);
 			path = iOS;
@@ -795,6 +797,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "SwiftSample (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
@@ -825,6 +828,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "SwiftSample (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
@@ -857,10 +861,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Sources/Supporting Files/macOS/macOS.entitlements";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -872,6 +878,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.samples.SwiftSample;
 				PRODUCT_NAME = SwiftSample;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -884,10 +891,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Sources/Supporting Files/macOS/macOS.entitlements";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -899,6 +908,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.samples.SwiftSample;
 				PRODUCT_NAME = SwiftSample;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -970,15 +980,15 @@
 			repositoryURL = "https://github.com/auth0/Auth0.swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = 2.6.0;
 			};
 		};
 		5CD3A4622784F5F900B67D88 /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nalexn/ViewInspector";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.1;
+				kind = exactVersion;
+				version = 0.9.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Sample-01/Tests/Shared/ProfileCellTests.swift
+++ b/Sample-01/Tests/Shared/ProfileCellTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import ViewInspector
 @testable import SwiftSample
 
-extension ProfileCell: Inspectable {}
-
 class ProfileCellTests: XCTestCase {
     private var sut: ProfileCell!
 

--- a/Sample-01/Tests/Shared/ProfileViewTests.swift
+++ b/Sample-01/Tests/Shared/ProfileViewTests.swift
@@ -3,8 +3,6 @@ import XCTest
 import ViewInspector
 @testable import SwiftSample
 
-extension ProfileView: Inspectable {}
-
 class ProfileViewTests: XCTestCase {
     func testHasHeader() throws {
         let user = User(id: "", name: "", email: "", emailVerified: "", picture: "", updatedAt: "")

--- a/Sample-01/Tests/iOS/HeroViewTests.swift
+++ b/Sample-01/Tests/iOS/HeroViewTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import ViewInspector
 @testable import SwiftSample
 
-extension HeroView: Inspectable {}
-
 class HeroViewTests: XCTestCase {
     private let sut = HeroView()
 

--- a/Sample-01/Tests/iOS/ProfileHeaderTests.swift
+++ b/Sample-01/Tests/iOS/ProfileHeaderTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import ViewInspector
 @testable import SwiftSample
 
-extension ProfileHeader: Inspectable {}
-
 class ProfileHeaderTests: XCTestCase {
     private let sut = ProfileHeader(picture: "")
 

--- a/Sample-01/Tests/macOS/HeroViewTests.swift
+++ b/Sample-01/Tests/macOS/HeroViewTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import ViewInspector
 @testable import SwiftSample
 
-extension HeroView: Inspectable {}
-
 class HeroViewTests: XCTestCase {
     private let sut = HeroView()
 

--- a/Sample-01/Tests/macOS/ProfileHeaderTests.swift
+++ b/Sample-01/Tests/macOS/ProfileHeaderTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import ViewInspector
 @testable import SwiftSample
 
-extension ProfileHeader: Inspectable {}
-
 class ProfileHeaderTests: XCTestCase {
     private let sut = ProfileHeader(picture: "")
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)

<!-- 
❗ The above item is required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR updates the sample app to use Universal Links as callback and logout URLs on iOS 17.4+ and macOS 14.4+.

### 📎 References

https://github.com/auth0/Auth0.swift/pull/832

### 🎯 Testing

The changes were tested manually on iOS 17.4 beta 3, using Xcode 15.3 beta 3 (15E5194e).